### PR TITLE
Setup sets inputs as env vars with a default

### DIFF
--- a/.github/workflows/update_data.yaml
+++ b/.github/workflows/update_data.yaml
@@ -46,7 +46,7 @@ jobs:
           then
             echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[[.[].tagName | match("\\d+") | .string ] | max]')" > "$GITHUB_OUTPUT"
           else
-            echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | select(endswith($SEASON_REBUILD | tostring)) | match("\\d+") | .string]')" > "$GITHUB_OUTPUT"
+            echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | select(endswith(${{SEASON_REBUILD}} | tostring)) | match("\\d+") | .string]')" > "$GITHUB_OUTPUT"
           fi
 
   update_pbp:

--- a/.github/workflows/update_data.yaml
+++ b/.github/workflows/update_data.yaml
@@ -46,7 +46,7 @@ jobs:
           then
             echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[[.[].tagName | match("\\d+") | .string ] | max]')" > "$GITHUB_OUTPUT"
           else
-            echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | select(endswith(${{SEASON_REBUILD}} | tostring)) | match("\\d+") | .string]')" > "$GITHUB_OUTPUT"
+            echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | select(endswith(${{ env.SEASON_REBUILD }} | tostring)) | match("\\d+") | .string]')" > "$GITHUB_OUTPUT"
           fi
 
   update_pbp:

--- a/.github/workflows/update_data.yaml
+++ b/.github/workflows/update_data.yaml
@@ -39,14 +39,14 @@ jobs:
     steps:
       - id: query_seasons
         run: |
-          if [ ${FULL_REBUILD} == true ]
+          if [ $FULL_REBUILD == true ]
           then
             echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | match("\\d+") | .string ]')" > "$GITHUB_OUTPUT"
-          elif [ ${SEASON_REBUILD} == 9999 ]
+          elif [ $SEASON_REBUILD == 9999 ]
           then
             echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[[.[].tagName | match("\\d+") | .string ] | max]')" > "$GITHUB_OUTPUT"
           else
-            echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | select(endswith(${SEASON_REBUILD} | tostring)) | match("\\d+") | .string]')" > "$GITHUB_OUTPUT"
+            echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | select(endswith($SEASON_REBUILD | tostring)) | match("\\d+") | .string]')" > "$GITHUB_OUTPUT"
           fi
 
   update_pbp:

--- a/.github/workflows/update_data.yaml
+++ b/.github/workflows/update_data.yaml
@@ -19,7 +19,7 @@ on:
         default: 9999
         type: number
       full_rebuild:
-        description: 'Full Rebuild'
+        description: 'Full Rebuild (overwrites above season)'
         required: true
         default: false
         type: boolean
@@ -32,19 +32,21 @@ jobs:
     name: pbp_setup
     env:
       GH_TOKEN: ${{ secrets.NFLVERSE_GH_TOKEN }}
+      FULL_REBUILD: ${{ inputs.full_rebuild || false }}
+      SEASON_REBUILD: ${{ inputs.season_rebuild || 9999 }}
     outputs:
       seasons: ${{ steps.query_seasons.outputs.seasons }}
     steps:
       - id: query_seasons
         run: |
-          if [ ${{ inputs.full_rebuild }} == true ]
+          if [ ${FULL_REBUILD} == true ]
           then
             echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | match("\\d+") | .string ]')" > "$GITHUB_OUTPUT"
-          elif [ ${{ inputs.season_rebuild }} == 9999 ]
+          elif [ ${SEASON_REBUILD} == 9999 ]
           then
             echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[[.[].tagName | match("\\d+") | .string ] | max]')" > "$GITHUB_OUTPUT"
           else
-            echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | select(endswith(${{ inputs.season_rebuild }} | tostring)) | match("\\d+") | .string]')" > "$GITHUB_OUTPUT"
+            echo "seasons=$(gh release list -R nflverse/nflverse-pbp --json tagName --jq '[.[].tagName | select(endswith(${SEASON_REBUILD} | tostring)) | match("\\d+") | .string]')" > "$GITHUB_OUTPUT"
           fi
 
   update_pbp:

--- a/.github/workflows/update_data.yaml
+++ b/.github/workflows/update_data.yaml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         season: ${{ fromJson(needs.pbp_setup.outputs.seasons) }}
-        type: ["pbp", "pbp_stats", "laterals"]
+        type: ["pbp", "pbp_stats"]
     env:
       GITHUB_PAT: ${{ secrets.NFLVERSE_GH_TOKEN }}
       NFLVERSE_UPDATE_SEASON: ${{ matrix.season }}
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        type: ["ps_off_comb", "ps_def_comb", "ps_kick_comb"]
+        type: ["ps_off_comb", "ps_def_comb", "ps_kick_comb", "laterals"]
     env:
       GITHUB_PAT: ${{ secrets.NFLVERSE_GH_TOKEN }}
       NFLVERSE_UPDATE_TYPE: ${{ matrix.type }}

--- a/R/update_multiple_laterals.R
+++ b/R/update_multiple_laterals.R
@@ -1,82 +1,35 @@
-release_lateral_yards <- function(s) {
-  check_lateral_yards <- function(id){
-    cli::cli_progress_step("Loading {id}")
-    season <- substr(id, 1, 4)
-    base_url <- "https://github.com/nflverse/nflfastR-raw/raw/master/raw"
-    load_url <- file.path(base_url, season, paste0(id, ".rds"))
-    raw_data <- nflreadr::rds_from_url(load_url)
-    plays <- janitor::clean_names(raw_data[[1]][[1]]$gameDetail$plays) |>
-      dplyr::select(play_id, play_stats)
-    stats <- tidyr::unnest(plays, cols = c("play_stats")) |>
-      janitor::clean_names() |>
-      dplyr::filter(stat_id %in% c(12, 13, 23, 24)) |>
-      dplyr::mutate(
-        game_id = as.character(id),
-        type = dplyr::if_else(stat_id %in% 12:13, "lateral_rushing", "lateral_receiving", missing = NA_character_)
-      ) |>
-      dplyr::select(
-        "game_id",
-        "play_id",
-        "stat_id",
-        "type",
-        "yards",
-        "team_abbr" = "team_abbreviation",
-        "player_name",
-        "gsis_player_id"
-      )
-
-    stats
-  }
-
-  games <- nflreadr::load_schedules(s) |>
-    dplyr::filter(!is.na(result))
-
-  if(length(games$game_id) == 0){
-    cli::cli_alert_info("No games yet, nothing to do")
-    return(invisible(NULL))
-  }
-
-  cli::cli_alert_info("Load {.val {length(games$game_id)}} game{?s} of {.val {s}}")
-
-  load <- furrr::future_map_dfr(games$game_id, check_lateral_yards)
-
-  cli::cli_alert_info("Process raw data...")
-
-  old <- readr::read_csv("lateral_yards/multiple_lateral_yards.csv", show_col_types = FALSE)
-
-  all <-
-    dplyr::bind_rows(
-      old,
-      load |>
-        nflfastR::decode_player_ids() |>
-        dplyr::group_by(game_id, play_id) |>
-        dplyr::filter(dplyr::n() > 1) |>
-        dplyr::ungroup() |>
-        suppressMessages()
+release_lateral_yards <- function(...){
+  cli::cli_progress_step("Release multiple lateral yards data...")
+  all_stat_ids <-
+    purrr::map(
+      seq(1999, nflreadr::most_recent_season()),
+      ~ nflreadr::rds_from_url(glue::glue("https://github.com/nflverse/nflverse-pbp/releases/download/playstats/play_stats_{.x}.rds")),
+      .progress = TRUE
     ) |>
-    dplyr::distinct() |>
-    dplyr::arrange(game_id, play_id)
+    purrr::list_rbind()
 
-  cli::cli_alert_info("Save multiple lateral plays...")
+  multiple_laterals <- all_stat_ids |>
+    dplyr::filter(stat_id %in% c(12, 13, 23, 24)) |>
+    dplyr::group_by(game_id, play_id) |>
+    dplyr::filter(dplyr::n() > 1) |>
+    dplyr::ungroup() |>
+    dplyr::mutate(
+      type = dplyr::if_else(stat_id %in% 12:13, "lateral_rushing", "lateral_receiving", missing = NA_character_)
+    ) |>
+    dplyr::select(tidyselect::any_of(c(
+      "game_id", "play_id", "stat_id", "type", "yards",
+      "team_abbr", "player_name", "gsis_player_id"
+    )))
 
-  readr::write_csv(all, "lateral_yards/multiple_lateral_yards.csv")
+  nflversedata::nflverse_save(
+    data_frame = multiple_laterals,
+    file_name = "multiple_lateral_yards",
+    nflverse_type = "multiple_lateral_yards",
+    release_tag = "misc",
+    file_types = c("rds", "csv")
+  )
 
-  # check if file has changed to trigger nflverse release
-  comp <- waldo::compare(old, all)
-
-  if (length(comp) != 0){
-    nflversedata::nflverse_save(
-      data_frame = all,
-      file_name = "multiple_lateral_yards",
-      nflverse_type = "multiple_lateral_yards",
-      release_tag = "misc",
-      file_types = c("rds", "csv")
-    )
-  } else {
-    cli::cli_alert_info("Data has not changed.")
-  }
-
-  cli::cli_alert_info("DONE!")
-
+  cli::cli_progress_done()
   invisible(NULL)
+
 }


### PR DESCRIPTION
fixes #89 

inputs aren't available to scheduled workflow runs, so we write them in environment variables with a default (which is used in scheduled runs)